### PR TITLE
(@cat-org/configs, @cat-org/create-project, @cat-org/jest) Fix error

### DIFF
--- a/packages/configs/src/configs/babel.js
+++ b/packages/configs/src/configs/babel.js
@@ -13,6 +13,7 @@ export default {
     '@babel/preset-flow',
     '@babel/plugin-proposal-optional-chaining',
     '@cat-org/babel-plugin-transform-flow',
+    'babel-plugin-module-resolver',
   ],
   config: () => ({
     presets: [

--- a/packages/create-project/src/__tests__/__ignore__/testings.js
+++ b/packages/create-project/src/__tests__/__ignore__/testings.js
@@ -58,11 +58,11 @@ const basicUsage = {
 
     // Run commands
     'yarn add --dev @cat-org/configs',
-    'configs --install babel',
-    'configs --install prettier',
-    'configs --install lint',
-    'configs --install lint-staged',
-    'configs --install jest',
+    'yarn configs --install babel',
+    'yarn configs --install prettier',
+    'yarn configs --install lint',
+    'yarn configs --install lint-staged',
+    'yarn configs --install jest',
     'yarn add --dev flow-bin flow-typed',
     'yarn flow-typed install',
 

--- a/packages/create-project/src/stores/configs.js
+++ b/packages/create-project/src/stores/configs.js
@@ -16,7 +16,7 @@ class Configs extends Store {
     await this.execa(
       'yarn add --dev @cat-org/configs',
       ...['babel', 'prettier', 'lint', 'lint-staged', 'jest'].map(
-        (configName: string) => `configs --install ${configName}`,
+        (configName: string) => `yarn configs --install ${configName}`,
       ),
     );
   };

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -10,10 +10,10 @@
   "dependencies": {
     "@cat-org/utils": "^1.0.0-beta.19",
     "enzyme": "^3.9.0",
-    "enzyme-adapter-react-16": "^1.12.1",
     "fbjs": "^1.0.0"
   },
   "devDependencies": {
+    "enzyme-adapter-react-16": "^1.12.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },


### PR DESCRIPTION
- Add `babel-plugin-module-resolver` to `babel` in `@cat-org/configs`
- Fix creating project with `@cat-org/configs` in `@cat-org/create-project`
- Move `enzyme-adapter-react-16` to `devDependencies` of `@cat-org/jest`